### PR TITLE
Propuesta de routing por directorios y con raíz en server/Routing.tk

### DIFF
--- a/src/main/kotlin/com/g7/routing/eventos/EventoRoutes.kt
+++ b/src/main/kotlin/com/g7/routing/eventos/EventoRoutes.kt
@@ -1,11 +1,11 @@
-package com.g7.server
+package com.g7.routing.eventos
 
 import com.g7.evento.EventoDto
 import com.g7.evento.toDomain
 import com.g7.evento.toDto
 import com.g7.repo.EventoRepository
 import com.g7.repo.UsuarioRepository
-import com.g7.usuario.toDto
+import com.g7.server.requireUuidParam
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
@@ -17,11 +17,11 @@ import java.util.UUID
 
 fun Route.eventoRoutes() {
 
-    get("/eventos/") {
+    get {
         call.respond(HttpStatusCode.OK, EventoRepository.getEventos().map { it.toDto() })
     }
 
-    get("/eventos/{id}") {
+    get("/{id}") {
         val id = call.requireUuidParam("id") ?: return@get
         EventoRepository.findById(id)
             .onSuccess { evento ->
@@ -32,7 +32,7 @@ fun Route.eventoRoutes() {
             }
     }
 
-    post("/eventos") {
+    post {
         val eventoDto = call.receive<EventoDto>().copy(id = UUID.randomUUID())
         //TODO: generar una id en serio
         eventoDto.toDomain()
@@ -45,7 +45,7 @@ fun Route.eventoRoutes() {
             }
     }
 
-    get("/eventos/{id}/inscriptos") {
+    get("/{id}/inscriptos") {
         val id = call.requireUuidParam("id")?: return@get
 
         EventoRepository.findById(id)
@@ -58,7 +58,7 @@ fun Route.eventoRoutes() {
             }
     }
     //usuarioId debería venir del contexto (jwt)
-    post("eventos/{id}/inscriptos/{usuarioId}") {
+    post("/{id}/inscriptos/{usuarioId}") {
         val id = call.requireUuidParam("id")?: return@post
         val usuarioId = call.requireUuidParam("usuarioId")?: return@post
         val evento = EventoRepository.findById(id).getOrElse {
@@ -74,7 +74,7 @@ fun Route.eventoRoutes() {
             }
     }
 
-    delete ("eventos/{id}/inscriptos/{usuarioId}") {
+    delete ("/{id}/inscriptos/{usuarioId}") {
         val id = call.requireUuidParam("id")?: return@delete
         val usuarioId = call.requireUuidParam("usuarioId")?: return@delete
         EventoRepository.findById(id)

--- a/src/main/kotlin/com/g7/routing/usuarios/UsuarioRoutes.kt
+++ b/src/main/kotlin/com/g7/routing/usuarios/UsuarioRoutes.kt
@@ -1,0 +1,30 @@
+package com.g7.routing.usuarios;
+
+import com.g7.repo.UsuarioRepository
+import com.g7.usuario.UsuarioDto
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import java.util.UUID
+
+fun Route.usuarioRoutes() {
+
+    post {
+
+        val usuarioDto = call.receive < UsuarioDto > ().copy(id = UUID.randomUUID())
+
+        usuarioDto.toDomain()
+            .onSuccess {
+                usuario ->
+                    UsuarioRepository.save(usuario)
+                    call.respond(HttpStatusCode.Created, usuarioDto)
+            }
+            .onFailure {
+                call.respond(HttpStatusCode.BadRequest, "Erro al inscribir usuario: ${it.message}")
+            }
+
+    }
+
+}

--- a/src/main/kotlin/com/g7/server/Routing.kt
+++ b/src/main/kotlin/com/g7/server/Routing.kt
@@ -1,21 +1,13 @@
 package com.g7.server
 
-import com.g7.evento.EventoDto
-import com.g7.evento.toDomain
-import com.g7.evento.toDto
-import com.g7.repo.EventoRepository
-import com.g7.repo.UsuarioRepository
-import com.g7.usuario.UsuarioDto
-import com.g7.usuario.toDto
-import io.ktor.http.HttpStatusCode
+import com.g7.routing.eventos.eventoRoutes
+import com.g7.routing.usuarios.usuarioRoutes
 import io.ktor.server.application.*
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.server.request.receive
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.json.Json
 import io.ktor.serialization.kotlinx.json.*
-import java.util.UUID
 
 fun Application.configureRouting() {
     install(ContentNegotiation) {
@@ -31,18 +23,14 @@ fun Application.configureRouting() {
     routing {
         get("/") {
             call.respondText("Hello World!")
+            log.info("Root endpoint accessed")
         }
-        eventoRoutes()
-        post("/usuarios") {
-            val usuarioDto = call.receive<UsuarioDto>().copy(id = UUID.randomUUID())
-            usuarioDto.toDomain()
-                .onSuccess { usuario ->
-                    UsuarioRepository.save(usuario)
-                    call.respond(HttpStatusCode.Created, usuarioDto)
-                }
-                .onFailure {
-                    call.respond(HttpStatusCode.BadRequest, "Erro al inscribir usuario: ${it.message}")
-                }
+        route("/eventos") {
+            eventoRoutes()
+        }
+        route("/usuarios") {
+            usuarioRoutes()
         }
     }
+
 }


### PR DESCRIPTION
Tal vez podríamos poner en `server/Routing.tk` todas las rutas raices y con que empiezan

<img width="411" height="270" alt="image" src="https://github.com/user-attachments/assets/61ae4853-98f2-4d4e-b38d-53450beff120" />

Despues organizar cada grupo de rutas en algun directorio distinto 
<img width="258" height="136" alt="image" src="https://github.com/user-attachments/assets/a23b87c3-73cc-4575-a0c2-1135f4ab3228" />

Y en cada xxxRoutes.tk poner las rutas sin el prefijo, que declaramos una sola vez en el Routing.tk
<img width="254" height="472" alt="image" src="https://github.com/user-attachments/assets/d7e9daca-c2fd-4779-9689-98ef0cb54836" />
