### PR TITLE
Re organizo código

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,21 @@ docker run -p 8080:8080 ktor-app
 
 ### 🔹 Endpoints disponibles
 
-| Método | Endpoint                                | Descripción                                             | Parámetros                    |
-|--------|-----------------------------------------|---------------------------------------------------------|-------------------------------|
-| GET    | `/usuarios/`                            | Lista todos los usuarios                                |                               |
-| GET    | `/usuarios/{id}`                        | Obtiene un usuario                                      | `id: UUID`                    |
-| POST   | `/usuarios/`                            | Crea un nuevo usuario, el id es asignado por el backend | JSON body                     |
-| POST   | `/usuarios/login`                       | Devuelve un JWT si los datos son validos                | JSON body                     |
-| GET    | `/eventos/`                             | Lista todos los eventos                                 |                               |
-| GET    | `/eventos/{id}`                         | Obtiene un evento                                       | `id: UUID`                    |
-| POST   | `/eventos/`                             | Crea un nuevo evento, el id es asignado por el backend  | JSON body                     |
-| POST   | `/eventos/{id}/inscriptos/`             | Muestra todos los inscriptos en un evento               | `id: UUID`                    |
-| POST   | `/eventos/{id}/inscriptos/{usuarioId}/` | Inscribe un usuario en un evento                        | `id: UUID`, `usuarioId: UUID` |
-| DELETE | `/eventos/{id}/inscriptos/{usuarioId}/` | Cancela la inscripción                                  | `id: UUID`, `usuarioId: UUID` |
+| Método | Endpoint                            | Descripción                               | Protegida | Parámetros                    |
+|:------:|-------------------------------------|-------------------------------------------|:---------:|-------------------------------|
+|  GET   | `/usuarios`                         | Lista todos los usuarios                  |     ❌     |                               |
+|  GET   | `/usuarios/{id}`                    | Obtiene un usuario                        |     ❌     | `id: UUID`                    |
+|  POST  | `/usuarios`                         | Crea un nuevo usuario,                    |     ❌     | JSON body                     |
+|  POST  | `/usuarios/login`                   | Devuelve un JWT si los datos son válidos  |     ❌     | JSON body                     |
+|  GET   | `/eventos`                          | Lista todos los eventos                   |     ❌     |                               |
+|  GET   | `/eventos/{id}`                     | Obtiene un evento                         |     ❌     | `id: UUID`                    |
+|  POST  | `/eventos`                          | Crea un nuevo evento                      |    ✔️     | JSON body                     |
+|  GET   | `/eventos/{id}/inscriptos`          | Muestra todos los inscriptos en un evento |    ✔️     | `id: UUID`                    |
+|  POST  | `/eventos/{id}/inscriptos`          | Inscribirse a un evento                   |    ✔️     | `id: UUID`                    |
+| DELETE | `/eventos/{id}/inscriptos`          | Cancela la inscripción                    |    ✔️     | `id: UUID`                    |
+| DELETE | `/eventos/{id}/inscriptos/{userId}` | Cancela la inscripción de un usuario      |    ✔️     | `id: UUID`, `usuarioId: UUID` |
 
-Las rutas protegidas requieren un header `Authorization Bearer` obtenido en `/login`. 
+Las rutas protegidas requieren un header `Authorization Bearer` obtenido en `usuarios/login`. 
 
 ### 💡 Posibles endpoints
 

--- a/api-docs.md
+++ b/api-docs.md
@@ -4,17 +4,53 @@ Este documento describe los endpoints disponibles en la API, incluyendo métodos
 
 ---
 
-## Base URL
+## Consideraciones previas
 
-```
+### Base URL
+
+``` http
 http://localhost:8080
 ```
+
+### Errores
+
+Ante un error, la API retornará el código de error correspondiente, y el siguiente JSON:
+
+```json
+{
+  "error": "Some error message"
+}
+```
+
+### Autorización
+
+La autorización se realiza mediante JWT, para obtener la misma se debe llamar al endpoint [login](#login), y luego incluirla en el header de la siguiente forma:
+
+```http
+Authorization: Bearer <token>
+```
+
+En caso de intentar acceder a un Endpoint que requiera autorización, y no tener la JWT, se retornara `401 Unauthorized`
 
 ---
 
 ## Endpoints
 
-### 1. Registro de usuario
+### Índice
+
+- [Registro de usuario](#registro-de-usuario)
+- [Login](#login)
+- [Obtener usuarios](#obtener-usuarios)
+- [Obtener usuario por ID](#obtener-usuario-por-id)
+- [Crear un evento](#crear-un-evento)
+- [Obtener eventos](#obtener-eventos)
+- [Obtener evento](#obtener-evento)
+- [Ver Inscriptos](#ver-inscriptos)
+- [Inscribirse](#inscribirse)
+- [Cancelar Inscripcion](#cancelar-inscripcion)
+- [Cancelar Inscripcion de un Usuario](#cancelar-inscripcion-de-un-usuario)
+
+### Registro de usuario
 
 - **URL:** `/usuarios`
 - **Método:** `POST`
@@ -44,17 +80,11 @@ http://localhost:8080
 }
 ```
 
-- **409 Conflict** si el username ya existe:
-
-```json
-{
-  "error": "El nombre de usuario ya existe"
-}
-```
+- **409 Conflict** si el username ya existe
 
 ---
 
-### 2. Login
+### Login
 
 - **URL:** `usuarios/login`
 - **Método:** `POST`
@@ -79,22 +109,40 @@ http://localhost:8080
 }
 ```
 
-- **401 Unauthorized** si usuario o contraseña incorrectos:
-
-```json
-{
-  "error": "Usuario o contraseña incorrectos"
-}
-```
+- **401 Unauthorized** si usuario o contraseña incorrectos
 
 ---
 
-### 3. Obtener usuario por ID
+### Obtener usuarios
+
+- **URL:** `/usuarios`
+- **Método:** `GET`
+- Autorización: TODO: Requerir token JWT en el header.
+- **Descripción:** Devuelve los datos de todos los usuarios.
+
+#### Response
+
+- **200 OK**
+
+```json
+[
+  {
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "username": "pepito",
+  "type": "PARTICIPANTE"
+  }
+]
+```
+
+- **401 Unauthorized** si el token es inválido o expiró
+
+---
+
+### Obtener usuario por ID
 
 - **URL:** `/usuarios/{id}`
 - **Método:** `GET`
-- **Descripción:** Devuelve los datos de un usuario por su ID. TODO: Requerir token JWT en el header.
-
+- **Descripción:** Devuelve los datos de un usuario por su ID. TODO: Requerir token JWT
 
 #### Response
 
@@ -108,31 +156,17 @@ http://localhost:8080
 }
 ```
 
-- **404 Not Found** si no existe:
-
-```json
-{
-  "error": "Usuario with id 123e4567-e89b-12d3-a456-426614174000 not found"
-}
-```
-
-- **401 Unauthorized** si el token es inválido o expiró.
+- **404 Not Found** si no existe
+- **401 Unauthorized** si el token es inválido o expiró
 
 ---
 
-### 4. Crear un evento
+### Crear un evento
 
 - **URL:** `/eventos`
 - **Método:** `POST`
-- **Descripción:** Le permite a un organizador **loggeado** crear un evento. Requiere JWT.
-
-#### Headers
-
-```
-Authorization: Bearer <token>
-```
-
-Se obtiene el token en `/login`
+- **Descripción:** Le permite a un organizador crear un evento
+- **Autorizacion**: Requiere [login](#login)
 
 #### Request Body
 
@@ -155,9 +189,183 @@ Se obtiene el token en `/login`
 #### Response
 
 - **201 Created**
-- **401 Unauthorized** si el token es inválido o expiró.
+
+```json
+{
+  "id" : "570g8400-e29b-41h4-a716-446655440040",
+  "titulo": "Fiesta de prueba", 
+  "descripcion": "Evento de prueba para testear la API", 
+  "inicio": "2025-09-15T20:00:00", 
+  "duracion": 10800, 
+  "cupoMaximo": 100, 
+  "cupoMinimio": 10, 
+  "precio": 1500.5, 
+  "categorias": [
+    "FIESTA", 
+    "CONCIERTO"
+  ]
+}
+```
+
+- **401 Unauthorized** si el token es inválido o expiró
+- **404 Not Found** si el id de usuario de la jwt no se corresponde a un usuario en serio
 
 ---
+
+### Obtener eventos
+
+- **URL:** `/eventos`
+- **Método:** `GET`
+- **Query Params** TODO
+- **Descripción** Obtiene todos los eventos
+
+#### Response
+
+- **200 OK**
+
+```json
+[
+  {
+    "id" : "570g8400-e29b-41h4-a716-446655440040",
+    "titulo": "Fiesta de prueba",
+    "descripcion": "Evento de prueba para testear la API",
+    "inicio": "2025-09-15T20:00:00",
+    "duracion": 10800,
+    "cupoMaximo": 100,
+    "cupoMinimio": 10,
+    "precio": 1500.5,
+    "categorias": [
+    "FIESTA",
+    "CONCIERTO"
+    ]
+  }
+]
+```
+
+---
+
+### Obtener evento
+
+- **URL:** `/eventos/{id}`
+- **Método:** `GET`
+- **Descripción** Obtiene un evento
+
+#### Response
+
+- **200 OK**
+
+```json
+{
+  "id" : "570g8400-e29b-41h4-a716-446655440040",
+  "titulo": "Fiesta de prueba",
+  "descripcion": "Evento de prueba para testear la API",
+  "inicio": "2025-09-15T20:00:00",
+  "duracion": 10800,
+  "cupoMaximo": 100,
+  "cupoMinimio": 10,
+  "precio": 1500.5,
+  "categorias": [
+  "FIESTA",
+  "CONCIERTO"
+  ]
+}
+```
+
+- **404 Not Found** Si no lo encontró
+
+---
+
+### Ver Inscriptos
+
+- **URL:** `/eventos/{id}/inscriptos`
+- **Método:** `GET`
+- **Descripción** Obtiene todos los inscriptos de un evento
+- **Autorizacion**: Requiere [login](#login) y ser el organizador del evento
+
+### Response
+
+- **200 OK**
+
+```json
+[
+  {
+    "usuarioId": "5ed2f21f-8943-44ce-94a1-27d9edac098c", 
+    "horaInscripcion": "2025-09-03T12:01:26.569835", 
+    "tipo": "CONFIRMACION"
+  }, 
+  {
+    "usuarioId": "5ed2f21f-8943-44ce-94a1-27d9edac098c", 
+    "horaInscripcion": "2025-09-03T12:01:26.569835", 
+    "tipo": "ESPERA"
+  }
+]
+```
+
+- **403 Forbidden** Si alguien que no es el organizador intenta acceder
+- **404 Not Found** Si no se encuentra el evento, o el usuario de la JWT
+
+---
+
+### Inscribirse
+
+- **URL:** `/eventos/{id}/inscriptos`
+- **Método:** `POST`
+- **Descripción** Se inscribe a un evento, puede quedar confirmado o en espera
+- **Autorizacion**: Requiere [login](#login) y no ser el organizador del evento
+
+#### Response
+
+- **200 OK**
+
+```json
+{
+  "usuarioId": "5ed2f21f-8943-44ce-94a1-27d9edac098c",
+  "horaInscripcion": "2025-09-03T12:01:26.569835",
+  "tipo": "CONFIRMACION"
+}
+```
+
+o
+
+```json
+{
+  "usuarioId": "5ed2f21f-8943-44ce-94a1-27d9edac098c",
+  "horaInscripcion": "2025-09-03T12:01:26.569835",
+  "tipo": "ESPERA"
+}
+```
+
+- **403 Forbidden**  Si el organizador se intenta inscribir a su propio evento
+- **404 Not Found** Si no encuentra el evento o el usuario de la JWT
+
+### Cancelar Inscripcion
+
+- **URL:** `/eventos/{id}/inscriptos`
+- **Método:** `DELETE`
+- **Descripción** Cancela la inscripción a un evento.
+- **Autorizacion**: Requiere [login](#login)
+
+#### Response
+
+- **200 OK**
+- **400 Bad Request** Si no estaba inscripto
+- **404 Not Found** Si no se encuentra el evento o el usuario de la JWT
+
+---
+
+### Cancelar Inscripcion de un Usuario
+
+- **URL:** `/eventos/{id}/inscriptos/{userId}`
+- **Método:** `DELETE`
+- **Descripción** Cancela la inscripción a un evento de un usuario.
+- **Autorizacion**: Requiere [login](#login) y ser el organizador del evento
+
+#### Response
+
+- **200 OK**
+- **400 Bad Request** Si no estaba inscripto
+- **403 Forbidden** Si el usuario de la JWT no es el organizador
+- **404 Not Found** Si no se encuentra el evento o el usuario de la JWT
 
 ## Notas
 
@@ -172,11 +380,12 @@ Se obtiene el token en `/login`
 2. Definir DTOs de request/response.
 3. Agregar sección al README siguiendo el mismo formato:
 
-```
-### N. Nombre del endpoint
-- URL:
-- Método:
-- Descripción:
-- Request Body:
-- Response:
+```markdown
+### Nombre del endpoint
+- **URL:**
+- **Método:**
+- **Descripción:**
+- **Autorizacion:**
+#### Request Body
+#### Response
 ```

--- a/src/main/kotlin/com/g7/routing/eventos/EventoLoggedRoutes.kt
+++ b/src/main/kotlin/com/g7/routing/eventos/EventoLoggedRoutes.kt
@@ -1,0 +1,98 @@
+package com.g7.routing.eventos
+
+import com.g7.evento.EventoDto
+import com.g7.evento.toDomain
+import com.g7.evento.toDto
+import com.g7.repo.EventoRepository
+import com.g7.server.fetchEvento
+import com.g7.server.fetchUsuario
+import com.g7.server.middleware.login.loggedUser
+import com.g7.server.requireUuidParam
+import com.g7.server.respondError
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import java.util.UUID
+
+fun Route.eventoLoggedRoutes() {
+    post {
+        val userId = call.loggedUser()?.id ?: return@post call
+            .respondError(HttpStatusCode.Unauthorized, "No se pudo obtener el usuario logueado")
+        val eventoDto = call.receive<EventoDto>()
+            .copy(organizador = userId, id = UUID.randomUUID())
+        //TODO: generar una id en serio
+        eventoDto.toDomain()
+            .onSuccess {
+                EventoRepository.saveEvento(it)
+                call.respond(HttpStatusCode.Created, eventoDto)
+            }
+            .onFailure { call.respondError(HttpStatusCode.BadRequest, it.message) }
+    }
+
+    get("/{id}/inscriptos") {
+        val id = call.requireUuidParam("id")?: return@get
+        val user = call.loggedUser() ?: return@get call.respond(HttpStatusCode.Unauthorized)
+        val evento = call.fetchEvento(id) ?: return@get
+
+        if (user.id != evento.organizador.id) {
+            return@get call.respondError(HttpStatusCode.Unauthorized, "Solo el organizador puede verlo")
+        }
+
+        val inscriptos = evento.inscriptos.map { it.toDto() } + evento.enEspera.map { it.toDto() }
+        call.respond(HttpStatusCode.OK, inscriptos)
+
+    }
+
+    post("/{id}/inscriptos") {
+        val id = call.requireUuidParam("id") ?: return@post
+        val userLog = call.loggedUser() ?: return@post call.respond(HttpStatusCode.Unauthorized)
+
+        val evento = call.fetchEvento(id) ?: return@post
+        val usuario = call.fetchUsuario(userLog.id) ?: return@post
+
+        if (usuario.id == evento.organizador.id) {
+            return@post call.respondError(HttpStatusCode.Forbidden,
+                "El organizador no puede inscribirse en su propio evento")
+        }
+
+        evento.inscribir(usuario)
+            .onSuccess { call.respond(HttpStatusCode.OK, it.toDto()) }
+            .onFailure { call.respondError(HttpStatusCode.BadRequest, it.message) }
+    }
+
+    delete("/{id}/inscriptos") {
+        val id = call.requireUuidParam("id") ?: return@delete
+        val user = call.loggedUser() ?: return@delete call.respond(HttpStatusCode.Unauthorized)
+
+        val evento = call.fetchEvento(id) ?: return@delete
+        val usuario = call.fetchUsuario(user.id) ?: return@delete
+
+        evento.cancelar(usuario)
+            .onSuccess { call.respond(HttpStatusCode.OK) }
+            .onFailure { call.respondError(HttpStatusCode.BadRequest, it.message) }
+    }
+
+    delete("/{id}/inscriptos/{userId}") {
+        val id = call.requireUuidParam("id") ?: return@delete
+        val user = call.loggedUser() ?: return@delete call.respond(HttpStatusCode.Unauthorized)
+
+        val evento = call.fetchEvento(id) ?: return@delete
+        var usuario = call.fetchUsuario(user.id) ?: return@delete
+
+        if (usuario.id != evento.organizador.id) {
+            return@delete call.respondError(HttpStatusCode.Forbidden,
+                "solo el organizador puede echar a alguien")
+        }
+
+        val userId = call.requireUuidParam("userId") ?: return@delete
+        usuario = call.fetchUsuario(userId) ?: return@delete
+
+        evento.cancelar(usuario)
+            .onSuccess { call.respond(HttpStatusCode.OK) }
+            .onFailure { call.respondError(HttpStatusCode.BadRequest, it.message) }
+    }
+}

--- a/src/main/kotlin/com/g7/routing/eventos/EventoRoutes.kt
+++ b/src/main/kotlin/com/g7/routing/eventos/EventoRoutes.kt
@@ -1,96 +1,30 @@
 package com.g7.routing.eventos
 
-import com.g7.evento.EventoDto
-import com.g7.evento.toDomain
 import com.g7.evento.toDto
 import com.g7.repo.EventoRepository
 import com.g7.repo.UsuarioRepository
-import com.g7.server.loggedUser
+import com.g7.server.fetchEvento
 import com.g7.server.requireUuidParam
 import com.g7.server.respondError
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.request.receive
+import io.ktor.server.auth.authenticate
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
-import io.ktor.server.routing.post
-import java.util.UUID
 
 fun Route.eventoRoutes() {
-
     get {
         call.respond(HttpStatusCode.OK, EventoRepository.getEventos().map { it.toDto() })
     }
 
     get("/{id}") {
         val id = call.requireUuidParam("id") ?: return@get
-        EventoRepository.findById(id)
-            .onSuccess { evento ->
-                call.respond(HttpStatusCode.OK, evento.toDto())
-            }
-            .onFailure {
-                call.respondError(HttpStatusCode.NotFound, "${it.message}")
-            }
+        val evento = call.fetchEvento(id) ?: return@get
+        call.respond(HttpStatusCode.OK, evento.toDto())
     }
-
-    post {
-        val userId = call.loggedUser()?.id ?: return@post call
-            .respondError(HttpStatusCode.Unauthorized, "No se pudo obtener el usuario logueado")
-        val eventoDto = call.receive<EventoDto>()
-            .copy(organizador = userId, id = UUID.randomUUID())
-        //TODO: generar una id en serio
-        eventoDto.toDomain()
-            .onSuccess {
-                EventoRepository.saveEvento(it)
-                call.respond(HttpStatusCode.Created, eventoDto)
-            }
-            .onFailure {
-                call.respondError(HttpStatusCode.BadRequest, "Error al inscribir el evento: ${it.message}")
-            }
-    }
-
-    get("/{id}/inscriptos") {
-        val id = call.requireUuidParam("id")?: return@get
-
-        EventoRepository.findById(id)
-            .onSuccess { evento ->
-                call.respond(HttpStatusCode.OK,
-                    evento.inscriptos.map { it.toDto() } + evento.enEspera.map { it.toDto() })
-            }
-            .onFailure {
-                call.respondError(HttpStatusCode.NotFound, "${it.message}")
-            }
-    }
-
-    post("/{id}/inscriptos") {
-        val id = call.requireUuidParam("id")?: return@post
-        val user = call.loggedUser() ?: return@post call.respond(HttpStatusCode.Unauthorized)
-        val evento = EventoRepository.findById(id).getOrElse {
-            return@post call.respond(HttpStatusCode.NotFound, it.message ?: "Unknown error")
-        }
-        val usuario = UsuarioRepository.getUsuarioFromId(user.id).getOrElse {
-            return@post call.respond(HttpStatusCode.NotFound, it.message ?: "Unknown error")
-        }
-        evento.inscribir(usuario)
-            .onSuccess { call.respond(HttpStatusCode.OK, it.toDto())}
-            .onFailure {
-                call.respondError(HttpStatusCode.BadRequest, it.message ?: "Unkown error")
-            }
-    }
-
-    delete ("/{id}/inscriptos/{usuarioId}") {
-        val id = call.requireUuidParam("id")?: return@delete
-        val usuarioId = call.requireUuidParam("usuarioId")?: return@delete
-        val evento = EventoRepository.findById(id).getOrElse {
-            return@delete call.respond(HttpStatusCode.NotFound, it.message ?: "Unknown error")
-        }
-        val usuario = UsuarioRepository.getUsuarioFromId(usuarioId).getOrElse {
-            return@delete call.respond(HttpStatusCode.NotFound, it.message ?: "Unknown error")
-        }
-        evento.cancelar(usuario)
-            .onSuccess { call.respond(HttpStatusCode.OK) }
-            .onFailure { call.respondError(HttpStatusCode.NotFound, it.message ?: "Unknown error") }
+    authenticate("auth-jwt") {
+        eventoLoggedRoutes()
     }
 
 }

--- a/src/main/kotlin/com/g7/routing/usuarios/UsuarioRoutes.kt
+++ b/src/main/kotlin/com/g7/routing/usuarios/UsuarioRoutes.kt
@@ -1,7 +1,7 @@
 package com.g7.routing.usuarios;
 
 import com.g7.repo.UsuarioRepository
-import com.g7.server.JwtConfig
+import com.g7.server.middleware.login.JwtConfig
 import com.g7.server.requireUuidParam
 import com.g7.server.respondError
 import com.g7.usuario.dto.LoginRequestDto

--- a/src/main/kotlin/com/g7/server/Application.kt
+++ b/src/main/kotlin/com/g7/server/Application.kt
@@ -1,9 +1,7 @@
 package com.g7.server
 
+import com.g7.server.middleware.configureMiddleware
 import io.ktor.server.application.*
-import io.ktor.server.auth.Authentication
-import io.ktor.server.auth.jwt.JWTPrincipal
-import io.ktor.server.auth.jwt.jwt
 import io.ktor.server.netty.EngineMain
 
 fun main(args: Array<String>) {
@@ -11,22 +9,7 @@ fun main(args: Array<String>) {
 }
 
 fun Application.module() {
-    JwtConfig.init(environment.config)
-
-    install(Authentication) {
-        jwt("auth-jwt") {
-            verifier(JwtConfig.verifier)
-            validate { credential ->
-                val userId = credential.payload.getClaim("userId").asString()
-                if (userId != null) {
-                    JWTPrincipal(credential.payload)
-                } else {
-                    null
-                }
-            }
-        }
-    }
-
+    configureMiddleware()
     configureRouting()
 }
 

--- a/src/main/kotlin/com/g7/server/Helpers.kt
+++ b/src/main/kotlin/com/g7/server/Helpers.kt
@@ -1,5 +1,9 @@
 package com.g7.server
 
+import com.g7.evento.Evento
+import com.g7.repo.EventoRepository
+import com.g7.repo.UsuarioRepository
+import com.g7.usuario.Usuario
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
@@ -7,7 +11,7 @@ import java.util.UUID
 
 /**
 * Busca el parámetro especificado de una UUID, si no lo encuentra envía la respuesta correspondiente
-* y retorna [null]
+* y retorna null
 * */
 suspend fun ApplicationCall.requireUuidParam(name: String): UUID? {
     val raw = parameters[name] ?: run {
@@ -22,6 +26,36 @@ suspend fun ApplicationCall.requireUuidParam(name: String): UUID? {
     }
 }
 
-suspend fun ApplicationCall.respondError(status: HttpStatusCode, message: String) {
-    this.respond(status, mapOf("error" to message))
+/**
+ * Busca el evento correspondiente al ID, retorna null si no lo encontró, y en ese caso responde por http
+ * esta función existe para manejar de forma centralizada todos los casos distintos de error
+ * aunque por ahora solo haya uno (no encontrado)
+ * */
+suspend fun ApplicationCall.fetchEvento(id: UUID): Evento? {
+    val result = EventoRepository.findById(id)
+    return result.getOrElse {
+        respondError(HttpStatusCode.NotFound, it.message)
+        null
+    }
+}
+
+/**
+ * Busca el evento correspondiente al ID, retorna null si no lo encontró, y en ese caso responde por http
+ * esta función existe para manejar de forma centralizada todos los casos distintos de error
+ * aunque por ahora solo haya uno (no encontrado)
+ * */
+suspend fun ApplicationCall.fetchUsuario(id: UUID): Usuario? {
+    val result = UsuarioRepository.getUsuarioFromId(id)
+    return result.getOrElse {
+        respondError(HttpStatusCode.NotFound, it.message)
+        null
+    }
+}
+
+/**
+ * Garantiza el formato de todos los errores, además de manejar centralizado el caso de que no haya
+ * mensaje. En un futuro también se podría utilizar para los logs
+ * */
+suspend fun ApplicationCall.respondError(status: HttpStatusCode, message: String? = null) {
+    respond(status, mapOf("error" to (message ?: "Unknown error")))
 }

--- a/src/main/kotlin/com/g7/server/Routing.kt
+++ b/src/main/kotlin/com/g7/server/Routing.kt
@@ -11,25 +11,13 @@ import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.auth.authenticate
 
 fun Application.configureRouting() {
-    install(ContentNegotiation) {
-        json(
-            Json {
-                prettyPrint = true
-                isLenient = true
-                ignoreUnknownKeys = true
-            }
-        )
-    }
-
     routing {
         get("/") {
             call.respondText("Hello World!")
             log.info("Root endpoint accessed")
         }
         route("/eventos") {
-            authenticate("auth-jwt") {
                 eventoRoutes()
-            }
         }
         route("/usuarios") {
             usuarioRoutes()

--- a/src/main/kotlin/com/g7/server/middleware/Configure.kt
+++ b/src/main/kotlin/com/g7/server/middleware/Configure.kt
@@ -1,0 +1,40 @@
+package com.g7.server.middleware
+
+import com.g7.server.middleware.login.JwtConfig
+import com.g7.server.respondError
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.jwt.jwt
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import kotlinx.serialization.json.Json
+
+fun Application.configureMiddleware() {
+    JwtConfig.init(environment.config)
+
+    install(Authentication) {
+        jwt("auth-jwt") {
+            verifier(JwtConfig.verifier)
+            validate { credential ->
+                val userId = credential.payload.getClaim("userId").asString()
+                if (userId != null) JWTPrincipal(credential.payload) else null
+            }
+            challenge { _, _ ->
+                call.respondError(HttpStatusCode.Unauthorized, "Token inválido o expirado")
+            }
+        }
+    }
+
+    install(ContentNegotiation) {
+        json(
+            Json {
+                prettyPrint = true
+                ignoreUnknownKeys = true
+            }
+        )
+    }
+
+}

--- a/src/main/kotlin/com/g7/server/middleware/login/JwtConfig.kt
+++ b/src/main/kotlin/com/g7/server/middleware/login/JwtConfig.kt
@@ -1,4 +1,4 @@
-package com.g7.server
+package com.g7.server.middleware.login
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.JWTVerifier

--- a/src/main/kotlin/com/g7/server/middleware/login/LoggedUser.kt
+++ b/src/main/kotlin/com/g7/server/middleware/login/LoggedUser.kt
@@ -1,4 +1,4 @@
-package com.g7.server
+package com.g7.server.middleware.login
 
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.jwt.JWTPrincipal


### PR DESCRIPTION
Parece bastant (y en parte lo és). pero lo principal es:

+ Submodulo middleware para poner ahí todo lo que necesiten
+ Un par de funciones auxiliares para los repo, simplificando la repetición lógica y únificando criterios de errores
+ Actualización a la documentación
  + Campo `protejido` en tabla del readme
  + Consideraciones previas en la documentación extensa para unificar lo repetido (cómo enviar la JWT, cómo responde errores)
  + Endpoints faltantes
+ No todos los endpoint de `/eventos` necesitan login
+ Chequeos más profundos de login (que el que envía sea el mismo que organiza el evento por ej)